### PR TITLE
Added try-except

### DIFF
--- a/Basic/ca.py
+++ b/Basic/ca.py
@@ -51,6 +51,10 @@ def tick():
 
 init_cells()
 while 1:
-    print_cells()
-    tick()
-    sleep(0.1)
+    try:
+        print_cells()
+        tick()
+        sleep(0.1)
+    except ValueError:
+        pass
+        


### PR DESCRIPTION
A ValueError can randomly occur on 32-bit systems due to recursion depth limits in the mainframe, but this doesn't actually affect the program so it is OK to ignore.